### PR TITLE
Release manifest: registry + record links, promoted-rc banner

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -98,6 +98,7 @@ jobs:
           data = yaml.safe_load(open(sys.argv[1]))
           print('version=' + str(data['version']))
           print('commit=' + str(data['commit']))
+          print('candidate=' + str(data.get('candidate') or ''))
           " "${file}"
           } >> "$GITHUB_OUTPUT"
 
@@ -213,6 +214,35 @@ jobs:
               --title  "${VERSION}" \
               --notes-file note.md
           fi
+
+      # The rc pre-release is kept forever (its digests are shared with the release,
+      # so deleting it is unsafe - see docs/RELEASE_PROCESS.md), which means readers can still land on it.
+      # Point them at the stable release it became, in a marked region like the manifest,
+      # so a re-run replaces the banner instead of stacking copies.
+      # A records file has no candidate, and a missing pre-release is a warning, not a failure:
+      # the release is already out, this banner is a courtesy.
+      - name: Mark the rc pre-release as promoted
+        if: steps.record.outputs.skip != 'true' && steps.record.outputs.candidate != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.record.outputs.version }}
+          CANDIDATE: ${{ steps.record.outputs.candidate }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "${CANDIDATE}" --json body -q .body > rc-body.md 2>/dev/null; then
+            echo "::warning::no pre-release found for ${CANDIDATE} - nothing to mark as promoted."
+            exit 0
+          fi
+          {
+            echo "<!-- promoted:begin -->"
+            echo "> [!IMPORTANT]"
+            echo "> Promoted to [${VERSION}](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${VERSION}) - same digests, byte-identical.  "
+            echo "> Use the stable release; this pre-release remains as the record of what was validated."
+            echo "<!-- promoted:end -->"
+            echo
+            sed '/<!-- promoted:begin -->/,/<!-- promoted:end -->/d' rc-body.md
+          } > rc-merged.md
+          gh release edit "${CANDIDATE}" --notes-file rc-merged.md
 
   # ------------------------------------------------------------------------------------------
   # Fresh build: an rc (schedule / dispatch) or a hand-cut major (release).

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -3,6 +3,63 @@
 The operator's runbook: consumers should read [Tags & versioning](../README.md#tags--versioning) instead.  
 This page is about *cutting* releases, and it is the only place the cadence and the procedures are documented/stated.
 
+## In a nutshell
+
+An rc is **built**, a release is that same rc **re-tagged**. Merging the candidate pull request is what promotes it:
+
+```mermaid
+graph LR
+    main["main"] -->|"cron, or gh workflow run"| build["fresh build<br>~40 min"]
+    build --> rc["pre-release v1.2-rc.1<br>every stage pushed"]
+    rc --> pr["candidate PR<br>adds releases/v1.2.yaml"]
+    pr -->|"you merge"| promote["re-tag the recorded digests<br>~90 s, no rebuild"]
+    promote --> release["release v1.2<br>+ latest"]
+```
+
+The whole cycle, on demand:
+
+```bash
+# 1. Cut the rc - fresh build from main HEAD, ~40 min.
+#    A dispatch bypasses the skip-when-unchanged check, so it always builds.
+gh workflow run docker-publish.yml --ref main
+
+# 2. Validate what it actually published, then read the candidate PR it opened.
+docker pull ghcr.io/guillaumedua/cpp-toolchain:dev-v1.2-rc.1
+
+# 3. Promote - merging the candidate PR is the entire procedure.
+gh pr merge release/candidate/v1.2-rc.1 --merge
+```
+
+Substitute the rc the dispatch actually minted: **you do not choose the number**.
+It is the newest release tag with its minor bumped, so with `v1.1` released the dispatch cuts `v1.2-rc.1`, and a second dispatch cuts `v1.2-rc.2` and closes the first candidate as superseded.
+
+### Promoting that rc as a major instead
+
+Same rc, same digests - only the record is retitled, between steps 2 and 3 above:
+
+```bash
+git fetch origin release/candidate/v1.2-rc.1
+git checkout release/candidate/v1.2-rc.1
+git mv releases/v1.2.yaml releases/v2.0.yaml
+# then edit that file: version: "v1.2" -> version: "v2.0"
+# leave candidate: untouched - it is what sources the digests being re-tagged
+git commit -am "Promote v1.2-rc.1 as v2.0"
+git push
+```
+
+Merging then re-tags the rc's digests to `v2.0` + `latest`.
+The schema sanctions exactly this one mismatch between `version` and `candidate` - a target ending in `.0` - and `bumps` survives the rename untouched, because it is recomputed against the newest release either way.
+The other route to a major, when no rc was built at the commit you want, is in [Cutting a major](#cutting-a-major).
+
+### What you cannot do
+
+| Not available | Why |
+| ------------- | --- |
+| Choose the rc number, or cut an rc *for* a given version | Computed from the newest release tag - see above |
+| Cut a minor by hand as a GitHub release | Refused: it would rebuild instead of promoting, shipping an artifact nobody tested |
+| Release a commit that is not on `main` | Both the build and the promotion assert containment in `main` - no cherry-pick channel |
+| Move `latest` faster than one build | The byte-identical guarantee costs one rc build, always |
+
 ## The model
 
 | Channel              | Cut by                                                | Moves `latest` | How                                                                                                     |
@@ -73,6 +130,13 @@ back to the old digests in seconds. The digests being in git is what makes this 
 > `v1.2`-shaped release tags are **refused**:  
 > minors ship by merging a candidate, never by cutting a release.  
 > A hand-cut minor would silently rebuild instead of promoting - an artifact nobody tested.
+
+```mermaid
+graph LR
+    q{"what are you<br>cutting?"} -->|"a minor"| a["merge the candidate PR as-is"]
+    q -->|"a major, and an rc<br>you validated exists"| b["retitle its record to v2.0, then merge<br>re-tag, no rebuild"]
+    q -->|"a major, at a commit<br>no rc was built at"| c["cut a v2.0 GitHub release by hand<br>fresh build, then a records-only PR"]
+```
 
 ### From a validated rc
 

--- a/scripts/details/render-manifest.py
+++ b/scripts/details/render-manifest.py
@@ -186,8 +186,13 @@ def main():
             row += f" {delta(current[name], previous.get(name))} |"
         out.append(row)
 
-    out += ["", "Every version above is pinned in the [Dockerfile](Dockerfile) and updated by Renovate, "
-                "so this is the image's contents, not a snapshot of them.", "", "<!-- manifest:end -->"]
+    out += [
+        "",
+        "Every version listed above is pinned in the [Dockerfile](Dockerfile) and kept current by Renovate,  ",
+        "so this table is the authoritative manifest of the image's contents, not a point-in-time snapshot.",
+        "",
+        "<!-- manifest:end -->"
+    ]
     print("\n".join(out))
 
 

--- a/scripts/details/render-manifest.py
+++ b/scripts/details/render-manifest.py
@@ -45,6 +45,10 @@ LABELS = [
     ("romkatv/powerlevel10k", "powerlevel10k"),
 ]
 
+# Registry pages the images are published to - hardcoded like LABELS, this script is repository-specific.
+GHCR_PAGE = "https://github.com/GuillaumeDua/cpp-toolchain/pkgs/container/cpp-toolchain"
+DOCKERHUB_PAGE = "https://hub.docker.com/r/guillaumedua/cpp-toolchain"
+
 
 def js_to_py(pattern):
     """Renovate regexes are JS; Python spells named groups (?P<x>) instead of (?<x>)."""
@@ -177,7 +181,26 @@ def main():
     ordered += sorted(name for name in current if name not in dict(LABELS))
     labels = dict(LABELS)
 
-    out = ["<!-- manifest:begin -->", f"## What's inside {args.tag}", ""]
+    # GHCR URLs cannot filter versions by tag name (its per-tag pages are keyed by a numeric
+    # version id only the Packages API knows), so the closest deep link is the tagged-only view.
+    out = [
+        "<!-- manifest:begin -->",
+        f"## What's inside {args.tag}",
+        "",
+        f"Published to [GHCR]({GHCR_PAGE}/versions?filters%5Bversion_type%5D=tagged)"
+        f" and [Docker Hub]({DOCKERHUB_PAGE}/tags?name={args.tag}) -"
+        f" `docker pull ghcr.io/guillaumedua/cpp-toolchain:{args.tag}`",
+        "",
+    ]
+    # The promotion record lands on main only when the candidate merges,
+    # so an rc cannot link it - once promoted, its banner points at the release, which can.
+    if not re.search(r"-rc\.\d+$", args.tag):
+        out += [
+            f"Scripts can read the promotion record, the manifest digest of every stage:"
+            f" [releases/{args.tag}.yaml]"
+            f"(https://github.com/GuillaumeDua/cpp-toolchain/blob/main/releases/{args.tag}.yaml)",
+            "",
+        ]
     out.append("| Component | Version |" + (f" Since {args.previous_ref} |" if diffing else ""))
     out.append("| --- | --- |" + (" --- |" if diffing else ""))
     for name in ordered:


### PR DESCRIPTION
- **[documentation] docs/RELEASE_PROCESS.md: add in-a-nutshell section, mermaid graphs for the release procedures**
- **[release] manifest: better wording**
- **[release] manifest: update pre-release manifest when promoted**
- **[release] manifest: link to release/xxx.yaml for scripts/bots, links to ghrc anb hub.docker for humans**
